### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ jQuery-Ajax-File-Upload
 
 Plugin to add support for file uploads using jQuery $.ajax()
 
-##What is this?
+## What is this?
 All this plugin does is:
 
 1. Grabs the files from file fields on change events and adds the data to an array.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
